### PR TITLE
Fix several errors and crashes caused by calls to disconnect_peer

### DIFF
--- a/steam-multiplayer-peer/steam_multiplayer_peer.cpp
+++ b/steam-multiplayer-peer/steam_multiplayer_peer.cpp
@@ -135,10 +135,10 @@ void SteamMultiplayerPeer::_close() {
 	if (connection_status != CONNECTION_CONNECTED) {
 		return;
 	}
-	_force_close();
+	force_close();
 }
 
-void SteamMultiplayerPeer::_force_close() {
+void SteamMultiplayerPeer::force_close() {
 	if (!_is_active()) {
 		return;
 	}
@@ -470,7 +470,7 @@ void SteamMultiplayerPeer::network_connection_status_changed(SteamNetConnectionS
 				// Connection failed
 				// Need to update connection_status for the connection_failed signal to be fired
 				// by SceneMultiplayer, even if we never finished connecting.
-				_force_close();
+				force_close();
 			}
 		} else {
 			if (connections_by_steamId64.has(steam_id)) {

--- a/steam-multiplayer-peer/steam_multiplayer_peer.h
+++ b/steam-multiplayer-peer/steam_multiplayer_peer.h
@@ -163,7 +163,7 @@ public:
 	bool _is_server() const override;
 	void _poll() override;
 	void _close() override;
-	void _force_close();
+	void force_close();
 	void _disconnect_peer(int32_t p_peer, bool p_force) override;
 	int32_t _get_unique_id() const override;
 	// void _set_refuse_new_connections(bool p_enable) override;


### PR DESCRIPTION
This PR addresses several issues related to disconnect_peer:
1. **Fixes the crash occurring on the host application immediately after calling disconnect_peer** (#12)
    This is done in a way similar to VirtualBrightPlayz's suggestion on the original issue (https://github.com/expressobits/steam-multiplayer-peer/issues/12#issuecomment-2833479178), except with a nullptr check instead of outright removing the line. I'm unsure what the purpose of flushing the connection for peer 0 is, but I reckon it might be important to keep.
2. **Fixes the peer_disconnected signal not being emitted on the host when calling disconnect_peer.**
    Without it, Godot's MultiplayerAPI would not be notified that the peer has been removed and would continue to attempt to send packets to them, causing a cascade of errors.
3. **Fixes an issue where Godot's MultiplayerAPI would fail to fire the `connection_failed` or `server_disconnected` signals on the client.**
    This was caused by calling `close()` when the client disconnects to update the connection_status, but `close()` returning early if the client hadn't finished connecting, and never successfully updating the status to disconnected. This fixes it by adding a `force_close` method that bypasses the connection status check.
    In my testing this issue happened occasionally because I had the host immediately disconnect the new peer after connecting. Steam's network status change callback _can_ sometimes skip from Connecting straight to ClosedByPeer, skipping the Connected status.

These three fixes were enough to fix most of the problems related to disconnecting in our game.