### PR TITLE
Fix client connection reliability: Add handshake retry mechanism in _poll

### DIFF
--- a/steam-multiplayer-peer/steam_multiplayer_peer.h
+++ b/steam-multiplayer-peer/steam_multiplayer_peer.h
@@ -3,6 +3,7 @@
 
 #include <godot_cpp/classes/multiplayer_peer_extension.hpp>
 #include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/classes/time.hpp>
 
 // Include Steamworks API headers
 #include "map"
@@ -18,6 +19,8 @@ class SteamMultiplayerPeer : public MultiplayerPeerExtension {
 	GDCLASS(SteamMultiplayerPeer, MultiplayerPeerExtension)
 
 private:
+	// Used to record the time of the last handshake packet sent
+    uint64_t last_handshake_time = 0;
 	enum Mode {
 		MODE_NONE,
 		MODE_SERVER,


### PR DESCRIPTION
### Problem
This PR addresses a critical issue where clients frequently fail to establish a Godot-level connection, despite the underlying Steamworks connection being successfully established (k_ESteamNetworkingConnectionState_Connected).
The root cause is a race condition or packet loss regarding the initial handshake packet. Currently, send_peer(unique_id) is called only once immediately upon connection. If this packet is lost (UDP) or arrives before the host is fully ready to process it, the host never registers the client's Godot Peer ID, and the peer_connected signal is never emitted. This leaves the client stuck in a limbo state (Steam connected, Godot disconnected).
This likely resolves Issue #43 and similar connection reliability reports.
### Solution
I implemented a handshake retry mechanism within the _poll() function:

1. Client-Side Check: The client checks if it has successfully registered the host (Peer ID 1) in peerId_to_steamId.
2. Retry Interval: If the Steam connection is active but the Godot handshake is incomplete, the client resends its send_peer(unique_id) packet every 500ms.
3. Auto-Stop: Once the host acknowledges the client (which syncs Peer ID 1 to the client), the condition !peerId_to_steamId.has(1) becomes false, and the retry logic stops executing immediately.

### Changes
steam_multiplayer_peer.h: Included <godot_cpp/classes/time.hpp> and added last_handshake_time member variable.
steam_multiplayer_peer.cpp: Added the retry logic block at the end of _poll().
### Testing
Tested in a production environment where connection failures were previously frequent.
Result: 10/10 successful consecutive connections.
Verified that the retry mechanism stops correctly after the connection is established, resulting in zero network overhead during gameplay